### PR TITLE
Fix UUID JSON serialization in score feedback saving

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -149,7 +149,7 @@ def get_result(item_id: UUID) -> ResultGetResponse:
 
 @app.post("/api/v1/score/feedback", response_model=ScoreFeedbackResponse)
 def score_feedback(req: ScoreFeedbackRequest) -> ScoreFeedbackResponse:
-    payload = req.model_dump()
+    payload = req.model_dump(mode="json")
     payload["comment"] = req.comment.strip()
     try:
         storage_info = gcs_feedback_store.save(payload)

--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -155,6 +155,7 @@ def test_score_feedback_success(monkeypatch):
         assert "score_request" in payload
         assert "score_response" in payload
         assert "comment" in payload
+        assert isinstance(payload["score_response"]["score_id"], str)
         return {"bucket": "test-bucket", "object_name": "score-feedback/test.json"}
 
     monkeypatch.setattr(gcs_feedback_store, "save", fake_save)


### PR DESCRIPTION
### Motivation
- The score feedback endpoint was saving a Pydantic model containing `UUID`/`datetime` values directly, which caused `Object of type UUID is not JSON serializable` when uploading to GCS.
- Tests should guard that the feedback payload uses JSON-safe primitives for identifiers to prevent runtime serialization errors.

### Description
- Use `req.model_dump(mode="json")` in `score_feedback` so `UUID` and `datetime` fields are converted to JSON-friendly primitives before saving to GCS.
- Add an assertion in `tests/test_api_score.py` to verify `payload["score_response"]["score_id"]` is a `str` in the mocked GCS save handler.
- These changes only affect how the feedback payload is serialized and do not change endpoint behavior or storage schema beyond making values JSON-serializable.

### Testing
- Running `pytest -q tests/test_api_score.py -k feedback` without `PYTHONPATH` failed during collection due to a module import error unrelated to serialization (failed).
- Re-running with `PYTHONPATH=. pytest -q tests/test_api_score.py -k feedback` succeeded with `2 passed, 9 deselected` (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69966838bd6083268fed8056eb7a4150)