### PR TITLE
Allow deleting final ura-dora entry in score UI

### DIFF
--- a/app/static/score_ui.html
+++ b/app/static/score_ui.html
@@ -655,7 +655,7 @@
         return ["kan", "ankan", "kakan"].includes(type) ? 4 : 3;
       }
 
-      function renderDoraList(rootId, list, labelPrefix, fallbackTile) {
+      function renderDoraList(rootId, list, labelPrefix, fallbackTile, minItems = 1) {
         const root = document.getElementById(rootId);
         root.innerHTML = "";
         list.forEach((tile, idx) => {
@@ -678,10 +678,10 @@
           delBtn.type = "button";
           delBtn.className = "mini-btn";
           delBtn.textContent = "削除";
-          delBtn.disabled = list.length <= 1;
+          delBtn.disabled = list.length <= minItems;
           delBtn.addEventListener("click", () => {
             list.splice(idx, 1);
-            if (!list.length) list.push(fallbackTile);
+            while (list.length < minItems) list.push(fallbackTile);
             renderDoraInputs();
           });
           item.appendChild(delBtn);
@@ -697,10 +697,10 @@
       }
 
       function renderDoraInputs() {
-        renderDoraList("doraTileRow", uiState.doraTiles, "ドラ牌", "4m");
-        renderDoraList("uraDoraTileRow", uiState.uraDoraTiles, "裏ドラ牌", "4m");
-        renderDoraList("doraIndicatorRow", uiState.doraIndicators, "ドラ表示牌", "4m");
-        renderDoraList("uraDoraIndicatorRow", uiState.uraDoraIndicators, "裏ドラ表示牌", "4m");
+        renderDoraList("doraTileRow", uiState.doraTiles, "ドラ牌", "4m", 1);
+        renderDoraList("uraDoraTileRow", uiState.uraDoraTiles, "裏ドラ牌", "4m", 0);
+        renderDoraList("doraIndicatorRow", uiState.doraIndicators, "ドラ表示牌", "4m", 1);
+        renderDoraList("uraDoraIndicatorRow", uiState.uraDoraIndicators, "裏ドラ表示牌", "4m", 0);
         syncDoraModeFromUi();
       }
 


### PR DESCRIPTION
### Motivation
- The UI prevented removing the last裏ドラ (ura-dora) entry because the dora list renderer enforced at least one item, but裏ドラ may legally be zero and must be removable.

### Description
- Added a `minItems` parameter to `renderDoraList` in `app/static/score_ui.html` and use it to control the minimum count per list.
- Updated delete-button enable/disable logic and post-delete normalization to respect `minItems`, and set `minItems=0` for `uraDoraTileRow`/`uraDoraIndicatorRow` while keeping `minItems=1` for regular dora lists.

### Testing
- Ran `pytest -q tests/test_api_score.py` and it passed (`25 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997b939673c8326ac0057d55068609a)