### PR TITLE
Add fu_breakdown to score results

### DIFF
--- a/app/schemas.py
+++ b/app/schemas.py
@@ -151,9 +151,15 @@ class Payments(BaseModel):
     total_received: int
 
 
+class FuBreakdownItem(BaseModel):
+    name: str
+    fu: int
+
+
 class ScoreResult(BaseModel):
     han: int
     fu: int
+    fu_breakdown: list[FuBreakdownItem] = Field(default_factory=list)
     yaku: list[YakuItem] = Field(default_factory=list)
     yakuman: list[str] = Field(default_factory=list)
     dora: DoraBreakdown

--- a/app/static/score_ui.html
+++ b/app/static/score_ui.html
@@ -1131,10 +1131,14 @@
           yakuBadges || yakumanBadges
             ? `<div class="badge-row">${yakuBadges}${yakumanBadges}</div>`
             : `<div class="badge-row"><span class="badge badge-empty">役なし</span></div>`;
+        const fuBreakdownText = (r.fu_breakdown || []).length
+          ? r.fu_breakdown.map((item) => `${item.name} ${item.fu}`).join(" + ")
+          : "-";
         document.getElementById("summary").innerHTML = `
           <div class="result-line"><strong>${r.point_label}</strong></div>
           ${roleBadgeHtml}
           <div class="result-line">翻: ${r.han} / 符: ${r.fu}</div>
+          <div class="result-line">符内訳: ${fuBreakdownText}</div>
           <div class="result-line">ロン: ${r.points.ron}</div>
           <div class="result-line">ツモ(親支払): ${r.points.tsumo_dealer_pay}</div>
           <div class="result-line">ツモ(子支払): ${r.points.tsumo_non_dealer_pay}</div>

--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -61,6 +61,7 @@ def test_score_ui_has_feedback_controls():
     assert "誤り指摘（GCS保存）" in response.text
     assert "和了形" in response.text
     assert "4面子1雀頭" in response.text
+    assert "符内訳" in response.text
 
 
 def test_score_endpoint_success():
@@ -70,6 +71,7 @@ def test_score_endpoint_success():
     assert body["status"] == "ok"
     assert body["result"]["han"] == 4
     assert body["result"]["points"]["ron"] == 7700
+    assert body["result"]["fu_breakdown"] == [{"name": "副底", "fu": 20}, {"name": "切り上げ", "fu": 10}]
     assert body["result"]["payments"]["hand_points_received"] == 7700
     assert body["result"]["payments"]["hand_points_with_honba"] == 7700
 

--- a/tests/test_hand_scoring.py
+++ b/tests/test_hand_scoring.py
@@ -40,6 +40,7 @@ def test_score_hand_shape_ron_non_dealer():
     result = score_hand_shape(base_hand(), base_context(), RuleSet())
     assert result.han == 4
     assert result.fu == 30
+    assert [item.model_dump() for item in result.fu_breakdown] == [{"name": "副底", "fu": 20}, {"name": "切り上げ", "fu": 10}]
     assert result.point_label == "通常"
     assert result.points.ron == 7700
     assert result.payments.hand_points_received == 7700
@@ -60,6 +61,26 @@ def test_score_hand_shape_tsumo_dealer():
     )
     result = score_hand_shape(base_hand(), context, RuleSet())
     assert any(y.name == "門前清自摸和" for y in result.yaku)
+
+
+
+def test_score_hand_shape_includes_fu_breakdown_for_pinfu_tsumo():
+    hand = HandInput(
+        closed_tiles=["1m", "2m", "3m", "4m", "5m", "6m", "3p", "4p", "5p", "6s", "7s", "8s", "5p", "5p"],
+        melds=[],
+        win_tile="5p",
+    )
+    context = base_context(
+        win_type="tsumo",
+        riichi=False,
+        aka_dora_count=0,
+        dora_indicators=[],
+        round_wind="E",
+        seat_wind="S",
+    )
+    result = score_hand_shape(hand, context, RuleSet())
+    assert result.fu == 20
+    assert [item.model_dump() for item in result.fu_breakdown] == [{"name": "副底", "fu": 20}]
 
 
 def test_score_hand_shape_payments_breakdown_with_honba_kyotaku():


### PR DESCRIPTION
### Motivation
- Expose the components of fu calculation in the score response so clients can display a human-readable breakdown of how the fu total was computed.
- Preserve existing scoring behavior while returning structured fu details for UI and API consumers.
- Make the UI show the fu breakdown so end users can verify the constituent fu values.

### Description
- Add a new `FuBreakdownItem` model and a `fu_breakdown: list[FuBreakdownItem]` field to `ScoreResult` in `app/schemas.py`.
- Implement `_build_fu_breakdown` in `app/hand_scoring.py` and populate `fu_breakdown` in `score_hand_shape` for normal hands, pinfu-tsumo (20-only), and yakuman (empty list).
- Update the score UI (`app/static/score_ui.html`) to render a `符内訳` line showing the breakdown joined by ` + `.
- Update unit and API tests (`tests/test_hand_scoring.py` and `tests/test_api_score.py`) to assert presence and contents of `fu_breakdown` for representative cases.

### Testing
- Ran `pytest -q tests/test_hand_scoring.py tests/test_api_score.py` and all tests passed (61 passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997bd8d2f388326a111368d4af2ebd3)