### PR TITLE
手配内で同種牌が5枚以上ならバリデーションエラーにする

### DIFF
--- a/app/validators.py
+++ b/app/validators.py
@@ -124,6 +124,13 @@ def validate_score_request(req: ScoreRequest) -> None:
     for tile in req.context.ura_dora_indicators:
         validate_tile(tile)
 
+    tile_counts: dict[str, int] = {}
+    for tile in all_tiles:
+        normalized = _normalize_tile(tile)
+        tile_counts[normalized] = tile_counts.get(normalized, 0) + 1
+        if tile_counts[normalized] >= 5:
+            raise HTTPException(status_code=422, detail=f"Tile appears 5+ times in hand: {normalized}")
+
     for meld in req.hand.melds:
         if meld.type in {"chi", "pon"} and len(meld.tiles) != 3:
             raise HTTPException(status_code=422, detail=f"{meld.type} must contain exactly 3 tiles")

--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -158,6 +158,32 @@ def test_score_endpoint_accepts_four_kans_hand():
     assert response.status_code == 200
 
 
+def test_score_endpoint_rejects_five_of_same_tile_including_red_five():
+    payload = valid_payload()
+    payload["hand"]["closed_tiles"] = [
+        "5m",
+        "5m",
+        "5m",
+        "5m",
+        "5mr",
+        "6m",
+        "7m",
+        "2p",
+        "2p",
+        "3p",
+        "3p",
+        "4p",
+        "4p",
+        "4p",
+    ]
+    payload["hand"]["win_tile"] = "4p"
+
+    response = client.post("/api/v1/score", json=payload)
+
+    assert response.status_code == 422
+    assert "Tile appears 5+ times in hand: 5m" in response.text
+
+
 def test_score_endpoint_rejects_non_winning_shape():
     payload = valid_payload()
     payload["hand"]["closed_tiles"] = ["1m", "2m", "3m", "4p", "5p", "6p", "7s", "8s", "9s", "E", "E", "E", "5mr", "5pr"]


### PR DESCRIPTION
### Motivation
- 手配の入力に現実的でない状態（同種牌が5枚以上含まれる）を早期に弾き、スコア計算や後続処理の前提を守るためのバリデーションを追加しました。赤5は同種扱い（`5mr/5pr/5sr` -> `5m/5p/5s`）とする仕様を満たします。

### Description
- `app/validators.py`: `validate_score_request` に全牌（`closed_tiles` + `melds``）を `_normalize_tile` で正規化して種類ごとにカウントし、同種が5枚以上になった時点で `HTTPException(status_code=422)` を送出する処理を追加しました.
- 赤5（`5mr/5pr/5sr`）は既存の `_normalize_tile` を利用して通常の `5m/5p/5s` として集計するようにしています.
- `tests/test_api_score.py`: `5m`×4 + `5mr`×1 を含むケースを追加し、API が `422` と期待メッセージを返すことを検証するテストを追加しました.

### Testing
- 部分実行で対象テストのみ: `pytest -q tests/test_api_score.py -k "five_of_same_tile or validation_error or rejects_non_winning_shape"` が成功して `3 passed, 23 deselected` となりました. 
- 全体実行でファイル全体: `pytest -q tests/test_api_score.py` が成功し `26 passed` でした.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997be7583a08326880dab96b344e7e4)