### PR TITLE
符計算の実装改善と符内訳反映による点数修正

### DIFF
--- a/tests/test_api_score.py
+++ b/tests/test_api_score.py
@@ -70,10 +70,10 @@ def test_score_endpoint_success():
     body = response.json()
     assert body["status"] == "ok"
     assert body["result"]["han"] == 4
-    assert body["result"]["points"]["ron"] == 7700
-    assert body["result"]["fu_breakdown"] == [{"name": "副底", "fu": 20}, {"name": "切り上げ", "fu": 10}]
-    assert body["result"]["payments"]["hand_points_received"] == 7700
-    assert body["result"]["payments"]["hand_points_with_honba"] == 7700
+    assert body["result"]["points"]["ron"] == 8000
+    assert body["result"]["fu_breakdown"] == [{"name": "副底", "fu": 20}, {"name": "門前ロン", "fu": 10}, {"name": "待ち", "fu": 2}, {"name": "面子", "fu": 8}]
+    assert body["result"]["payments"]["hand_points_received"] == 8000
+    assert body["result"]["payments"]["hand_points_with_honba"] == 8000
 
 
 def test_score_endpoint_validation_error():
@@ -91,11 +91,11 @@ def test_score_endpoint_includes_payment_breakdown():
     response = client.post("/api/v1/score", json=payload)
     assert response.status_code == 200
     payments = response.json()["result"]["payments"]
-    assert payments["hand_points_received"] == 7700
+    assert payments["hand_points_received"] == 8000
     assert payments["honba_bonus"] == 600
-    assert payments["hand_points_with_honba"] == 8300
+    assert payments["hand_points_with_honba"] == 8600
     assert payments["kyotaku_bonus"] == 1000
-    assert payments["total_received"] == 9300
+    assert payments["total_received"] == 9600
 
 
 def test_score_endpoint_accepts_kan_hand():

--- a/tests/test_hand_scoring.py
+++ b/tests/test_hand_scoring.py
@@ -39,13 +39,13 @@ def base_context(**kwargs) -> ContextInput:
 def test_score_hand_shape_ron_non_dealer():
     result = score_hand_shape(base_hand(), base_context(), RuleSet())
     assert result.han == 4
-    assert result.fu == 30
-    assert [item.model_dump() for item in result.fu_breakdown] == [{"name": "副底", "fu": 20}, {"name": "切り上げ", "fu": 10}]
-    assert result.point_label == "通常"
-    assert result.points.ron == 7700
-    assert result.payments.hand_points_received == 7700
-    assert result.payments.hand_points_with_honba == 7700
-    assert result.payments.total_received == 7700
+    assert result.fu == 40
+    assert [item.model_dump() for item in result.fu_breakdown] == [{"name": "副底", "fu": 20}, {"name": "門前ロン", "fu": 10}, {"name": "待ち", "fu": 2}, {"name": "面子", "fu": 8}]
+    assert result.point_label == "満貫"
+    assert result.points.ron == 8000
+    assert result.payments.hand_points_received == 8000
+    assert result.payments.hand_points_with_honba == 8000
+    assert result.payments.total_received == 8000
     assert any(y.name == "場風 東" for y in result.yaku)
 
 
@@ -89,11 +89,11 @@ def test_score_hand_shape_payments_breakdown_with_honba_kyotaku():
         kyotaku=1,
     )
     result = score_hand_shape(base_hand(), context, RuleSet())
-    assert result.payments.hand_points_received == 7700
+    assert result.payments.hand_points_received == 8000
     assert result.payments.honba_bonus == 600
-    assert result.payments.hand_points_with_honba == 8300
+    assert result.payments.hand_points_with_honba == 8600
     assert result.payments.kyotaku_bonus == 1000
-    assert result.payments.total_received == 9300
+    assert result.payments.total_received == 9600
 
 
 def test_score_hand_shape_limit_label_haneman():


### PR DESCRIPTION
### Motivation
- 既存の符計算が簡易的（固定的な30符/切り上げのみ）で実際の和了構成に即していなかったため、実符を正しく算出して点数へ反映する必要があった。

### Description
- `app/hand_scoring.py` に実手役向けの符算出ロジックを追加し、`_calc_regular_fu`、`_meld_fu`、`_pair_fu`、`_meld_tiles`、`_is_closed_hand` といった補助関数を実装して面子分解に基づく符内訳を求めるようにした。  
- 雀頭符（役牌・場/自風と `renpu_fu` ルール対応）、待ち符（単騎/嵌張/辺張）、面子符（明暗・么九判定を含むポン/カン）、門前ロン符、ツモ符、七対子25符、および10単位切り上げを反映するようにした。  
- 既存の固定符選択を廃止して `score_hand_shape` が `fu, fu_breakdown = _calc_regular_fu(...)` を使うように置換し、符変化が点数ラベルと支払い結果へ反映されるようにした。  
- API/ユニットテストの期待値を修正して、新しい符内訳（例: `副底`/`門前ロン`/`待ち`/`面子` 等）とそれに伴う点数・支払い結果を検証するように更新した。  

### Testing
- 自動テストを `pytest -q tests/test_hand_scoring.py tests/test_api_score.py` で実行し、合計 `62` 件のテストが全て成功しました（`62 passed`）。
- 変更にあわせて `tests/test_hand_scoring.py` と `tests/test_api_score.py` の期待値を更新し、新しい符内訳と点数計算をカバーしています。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997cbf0d5c08326a3d25125af7db8bf)