### PR TITLE
Determine dealer from seat_wind (East) for point/payment calculation

### DIFF
--- a/app/hand_scoring.py
+++ b/app/hand_scoring.py
@@ -560,8 +560,9 @@ def _base_points(han: int, fu: int) -> int:
 
 def _calc_points(context: ContextInput, han: int, fu: int, base_override: int | None = None) -> tuple[Points, Payments]:
     base = base_override if base_override is not None else _base_points(han, fu)
+    is_dealer = context.seat_wind.value == "E"
     if context.win_type == "ron":
-        ron = base * (6 if context.is_dealer else 4)
+        ron = base * (6 if is_dealer else 4)
         rounded = ((ron + 99) // 100) * 100
         honba_bonus = context.honba * 300
         kyotaku_bonus = context.kyotaku * 1000
@@ -578,7 +579,7 @@ def _calc_points(context: ContextInput, han: int, fu: int, base_override: int | 
             ),
         )
 
-    if context.is_dealer:
+    if is_dealer:
         each = ((base * 2 + 99) // 100) * 100
         hand_points_received = each * 3
         honba_bonus = context.honba * 300

--- a/tests/test_hand_scoring.py
+++ b/tests/test_hand_scoring.py
@@ -64,6 +64,37 @@ def test_score_hand_shape_tsumo_dealer():
 
 
 
+
+
+def test_score_hand_shape_uses_seat_wind_for_dealer_ron():
+    context = base_context(
+        win_type="ron",
+        is_dealer=False,
+        seat_wind="E",
+        round_wind="S",
+        riichi=True,
+        aka_dora_count=2,
+        dora_indicators=["4m"],
+    )
+    result = score_hand_shape(base_hand(), context, RuleSet())
+    assert result.points.ron == 12000
+
+
+def test_score_hand_shape_uses_seat_wind_for_dealer_tsumo():
+    context = base_context(
+        win_type="tsumo",
+        is_dealer=False,
+        seat_wind="E",
+        round_wind="S",
+        riichi=True,
+        aka_dora_count=2,
+        dora_indicators=["4m"],
+    )
+    result = score_hand_shape(base_hand(), context, RuleSet())
+    assert result.points.tsumo_dealer_pay == 4000
+    assert result.points.tsumo_non_dealer_pay == 4000
+    assert result.payments.hand_points_received == 12000
+
 def test_score_hand_shape_includes_fu_breakdown_for_pinfu_tsumo():
     hand = HandInput(
         closed_tiles=["1m", "2m", "3m", "4m", "5m", "6m", "3p", "4p", "5p", "6s", "7s", "8s", "5p", "5p"],


### PR DESCRIPTION
### Motivation
- Fix scoring for the rule that a player whose seat wind (`seat_wind`) is East should always be treated as the dealer for payment calculations even when `context.is_dealer` is false. 
- This ensures cases where the self wind is East result in dealer-style Ron/Tsumo payments (all payments come from non-dealers) as expected in standard mahjong rules.

### Description
- In `_calc_points` the dealer check was changed to compute `is_dealer = context.seat_wind.value == "E"` and use that value instead of `context.is_dealer` when computing Ron and Tsumo branches. 
- The Ron multiplier and Tsumo branching logic now reference `is_dealer` so dealer vs non-dealer rounding and per-player payments follow the seat wind. 
- Added regression tests in `tests/test_hand_scoring.py` to verify Ron and Tsumo outcomes when `is_dealer=False` but `seat_wind="E"`.

### Testing
- Ran `pytest -q tests/test_hand_scoring.py tests/test_api_score.py` and all tests passed. 
- Test run result: `64 passed` (including the newly added regression tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997e44288c483268f8f53d5bb28c5e8)