### PR TITLE
Fix PR #8 review comments: room_code, duplicate tenpai, WS timer leak

### DIFF
--- a/app/game_session.py
+++ b/app/game_session.py
@@ -320,8 +320,8 @@ def apply_draw(session: GameSession, tenpai_seats: list[int] | None = None,
 
     _take_snapshot(session)
 
-    tenpai_seats = tenpai_seats or []
-    riichi_seats = riichi_seats or []
+    tenpai_seats = list(dict.fromkeys(tenpai_seats or []))
+    riichi_seats = list(dict.fromkeys(riichi_seats or []))
     point_changes: dict[int, int] = {i: 0 for i in range(4)}
 
     # Apply riichi deductions

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -309,5 +309,6 @@ class RoundResultResponse(BaseModel):
 
 class GameRoundResponse(BaseModel):
     game_id: UUID
+    room_code: str | None = None
     round_result: RoundResultResponse
     game_state: GameStateResponse

--- a/app/static/game.html
+++ b/app/static/game.html
@@ -287,15 +287,21 @@ async function joinRoom() {
   }
 }
 
+let keepAliveTimer = null;
+
 function connectWS() {
   const proto = location.protocol === 'https:' ? 'wss:' : 'ws:';
   const url = `${proto}//${location.host}/ws/rooms/${roomCode}?player_name=${encodeURIComponent(myName)}`;
   ws = new WebSocket(url);
   ws.onopen = () => {
     document.getElementById('connStatus').classList.add('connected');
+    // Clear any previous keep-alive timer before creating a new one
+    if (keepAliveTimer) clearInterval(keepAliveTimer);
+    keepAliveTimer = setInterval(() => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'ping'})); }, 25000);
   };
   ws.onclose = () => {
     document.getElementById('connStatus').classList.remove('connected');
+    if (keepAliveTimer) { clearInterval(keepAliveTimer); keepAliveTimer = null; }
     // Auto-reconnect
     setTimeout(connectWS, 2000);
   };
@@ -314,8 +320,6 @@ function connectWS() {
     if (msg.type === 'player_joined') toast(`${msg.player_name} が参加`);
     if (msg.type === 'player_left') toast(`${msg.player_name} が退出`);
   };
-  // Keep-alive
-  setInterval(() => { if (ws.readyState === 1) ws.send(JSON.stringify({type:'ping'})); }, 25000);
 }
 
 function showGameScreen() {


### PR DESCRIPTION
- Add room_code field to GameRoundResponse schema so frontend receives it
- Deduplicate tenpai_seats/riichi_seats in apply_draw to prevent payout corruption
- Fix WebSocket keep-alive timer stacking by clearing previous interval on reconnect

https://claude.ai/code/session_01RJhnKTEzXEryhRTogS94Fg